### PR TITLE
remove obsolete config items

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Tinyproxy Docker image
  - `LOG_TO_SYSLOG`: When set to On, this option tells Tinyproxy to write its debug messages to syslog. Defaults to On
  - `LOG_LEVEL`: Sets the log level. Possible values are `Critical` (least verbose), `Error`, `Warning`, `Notice`, `Connect` (log connections without Info's noise), `Info` (most verbose). Defaults to Notice
  - `MAXCLIENTS`: Tinyproxy creates one child process for each connected client. This options specifies the absolute highest number processes that will be created
- - `MINSPARESERVERS` & `MAXSPARESERVERS`: Minimum and maximum number of spare servers to keep running. Defaults to 10 and 20 respectively
- - `STARTSERVERS`: The number of servers to start initially. Defaults to 10.
 
 ### Advanced configuration
 

--- a/root/etc/cont-init.d/90_tinyproxy.sh
+++ b/root/etc/cont-init.d/90_tinyproxy.sh
@@ -9,9 +9,6 @@ TP_CONF="/etc/tinyproxy/tinyproxy.conf"
 : ${LOG_TO_SYSLOG:="Yes"}
 : ${LOG_LEVEL:="Info"}
 : ${MAXCLIENTS:="100"}
-: ${MINSPARESERVERS:="10"}
-: ${MAXSPARESERVERS:="20"}
-: ${STARTSERVERS:="10"}
 
 if [[ ! -f $TP_CONF ]]
  then
@@ -24,9 +21,6 @@ LogLevel $LOG_LEVEL
 PidFile "/tmp/tinyproxy.pid"
 XTinyproxy Yes
 MaxClients $MAXCLIENTS
-MinSpareServers $MINSPARESERVERS
-MaxSpareServers $MAXSPARESERVERS
-StartServers $STARTSERVERS
 PidFile "/tmp/tinyproxy.pid"
 XTinyproxy Off 
 DisableViaHeader On


### PR DESCRIPTION
Hello,
I've noticed this 
```
WARNING: obsolete config item on line 9
WARNING: obsolete config item on line 10
WARNING: obsolete config item on line 11
```

It seems these config items are no longer available in tinyproxy https://github.com/tinyproxy/tinyproxy/blob/master/etc/tinyproxy.conf.in